### PR TITLE
fix device socket mount path

### DIFF
--- a/deployments/pod-sriovdp.yaml
+++ b/deployments/pod-sriovdp.yaml
@@ -10,17 +10,17 @@ spec:
     command: [ "/bin/bash", "-c", "--" ]
     args: [ "sriovdp --logtostderr 10;" ]
     volumeMounts:
-    - mountPath: /var/lib/kubelet/plugins_registry/
-      name: devicesock 
+    - mountPath: /var/lib/kubelet/
+      name: devicesock
       readOnly: false
     - mountPath: /sys/class/net
       name: net
       readOnly: true
   volumes:
-  - name: devicesock 
+  - name: devicesock
     hostPath:
      # directory location on host
-     path: /var/lib/kubelet/plugins_registry/
+     path: /var/lib/kubelet/
   - name: net
     hostPath:
       path: /sys/class/net

--- a/images/README.md
+++ b/images/README.md
@@ -28,7 +28,7 @@ Note: The likely best practice here is to build your own image given the Dockerf
 Example docker run command:
 
 ```
-$ docker run -it -v /var/lib/kubelet/plugins_registry/:/var/lib/kubelet/plugins_registry/ -v /sys/class/net:/sys/class/net --entrypoint=/bin/bash nfvpe/sriovdp
+$ docker run -it -v /var/lib/kubelet/:/var/lib/kubelet/ -v /sys/class/net:/sys/class/net --entrypoint=/bin/bash nfvpe/sriovdp
 ```
 
 Originally inspired by and is a portmanteau of the [Flannel daemonset](https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel.yml), the [Calico Daemonset](https://github.com/projectcalico/calico/blob/master/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-daemonset.yaml), and the [Calico CNI install bash script](https://github.com/projectcalico/cni-plugin/blob/be4df4db2e47aa7378b1bdf6933724bac1f348d0/k8s-install/scripts/install-cni.sh#L104-L153).

--- a/images/sriovdp-daemonset.yaml
+++ b/images/sriovdp-daemonset.yaml
@@ -46,7 +46,7 @@ spec:
           privileged: false
         volumeMounts:
         - name: devicesock
-          mountPath: /var/lib/kubelet/plugins_registry/
+          mountPath: /var/lib/kubelet/
           readOnly: false
         - name: net
           mountPath: /sys/class/net
@@ -54,7 +54,7 @@ spec:
       volumes:
         - name: devicesock
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: /var/lib/kubelet/
         - name: net
           hostPath:
             path: /sys/class/net


### PR DESCRIPTION
With kubelet plugin watcher mode enabled, either
{kubelet_root_dir}/device-plugins or
{kubelet_root_dir}/plugins_registry registration
pathes will be used depending on different kube
versions. This commit changes device socket mount
path to {kubelet_root_dir} in order to support both.

(cherry picked from commit c23c4f716e0338e03ef3e5e21faad669df0017bf)