### PR TITLE
wip(intel): adding support for X520 dual-10G DA/SFP+

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 SRIOV_DP_SYS_BINARY_DIR="/usr/bin"
 LOG_DIR=""
 LOG_LEVEL=10
-NIC_MODELS="--nic-model 0x8086-0x158b --nic-model 0x15b3-0x1015 --nic-model 0x15b3-0x1017"
+NIC_MODELS="--nic-model 0x8086-0x158b --nic-model 0x8086-0x154b --nic-model 0x15b3-0x1015 --nic-model 0x15b3-0x1017"
 
 function usage()
 {


### PR DESCRIPTION
Having experimented with some OCP 4.1 cluster, we successfully managed to get this working with some 8086:154b devices (X520, 2x 10G, from Intel, pretty similar to the X710 already supported).