### PR TITLE
Bug 1870074: pfName selector: match exact pf name (#263)

### DIFF
--- a/pkg/netdevice/vhostNet.go
+++ b/pkg/netdevice/vhostNet.go
@@ -8,7 +8,7 @@ import (
 
 // VhostNetDeviceExist returns true if /dev/vhost-net exists
 func VhostNetDeviceExist() bool {
-	_, err := os.Stat("/dev/vhost-net");
+	_, err := os.Stat("/dev/vhost-net")
 	return err == nil
 }
 

--- a/pkg/resources/deviceSelectors.go
+++ b/pkg/resources/deviceSelectors.go
@@ -193,7 +193,7 @@ func contains(hay []string, needle string) bool {
 
 func getItem(hay []string, needle string) string {
 	for _, item := range hay {
-		if strings.HasPrefix(item, needle) {
+		if strings.EqualFold(strings.Split(item, "#")[0], needle) {
 			return item
 		}
 	}


### PR DESCRIPTION
* pfName selector: match exact pf name

pfNames may contain names with overlapped prefix such as ens3f0, ens3;
this results in VFs from ens3 be wrongly exposed as extended resource
when pfNames only contain ens3f0.

* fix vhostnet syntax