### PR TITLE
Bug 2027676: Add the tun mounting with vhost is requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ This selector is applicable when "deviceType" is "netDevice"(note: this is defau
 | "linkTypes"   | N        | The link type of the net device associated with the PCI device | `string` list Default: `null`                     | "linkTypes": ["ether"]                                                                           |
 | "ddpProfiles" | N        | A map of device selectors                                      | `string` list Default: `null`                     | "ddpProfiles": ["GTPv1-C/U IPv4/IPv6 payload"]                                                   |
 | "isRdma"      | N        | Mount RDMA resources                                           | `bool`  values `true` or `false` Default: `false` | "isRdma": `true`                                                                                 |
-| "needVhostNet"| N        | Share /dev/vhost-net                                           | `bool`  values `true` or `false` Default: `false` | "needVhostNet": `true`                                                                           |
+| "needVhostNet"| N        | Share /dev/vhost-net and /dev/net/tun                          | `bool`  values `true` or `false` Default: `false` | "needVhostNet": `true`                                                                           |
 
 
 [//]: # (The tables above generated using: https://ozh.github.io/ascii-tables/)

--- a/pkg/netdevice/netInfoProviders.go
+++ b/pkg/netdevice/netInfoProviders.go
@@ -76,7 +76,15 @@ func (rip *vhostNetInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 		glog.Errorf("GetDeviceSpecs(): /dev/vhost-net doesn't exist")
 		return nil
 	}
-	return GetVhostNetDeviceSpec()
+	deviceSpec := GetVhostNetDeviceSpec()
+
+	if !TunDeviceExist() {
+		glog.Errorf("GetDeviceSpecs(): /dev/net/tun doesn't exist")
+		return nil
+	}
+	deviceSpec = append(deviceSpec, GetTunDeviceSpec()...)
+
+	return deviceSpec
 }
 
 func (rip *vhostNetInfoProvider) GetEnvVal() string {

--- a/pkg/netdevice/pciNetDevice_test.go
+++ b/pkg/netdevice/pciNetDevice_test.go
@@ -247,7 +247,7 @@ var _ = Describe("PciNetDevice", func() {
 				Expect(dev.GetDriver()).To(Equal("vfio-pci"))
 				Expect(dev.GetNetName()).To(Equal(""))
 				Expect(dev.GetEnvVal()).To(Equal("0000:00:00.1"))
-				Expect(dev.GetDeviceSpecs()).To(HaveLen(3)) // /dev/vfio/vfio0 and default /dev/vfio/vfio + vhost-net
+				Expect(dev.GetDeviceSpecs()).To(HaveLen(4)) // /dev/vfio/vfio0 and default /dev/vfio/vfio + vhost-net + tun
 				Expect(dev.GetRdmaSpec().IsRdma()).To(BeFalse())
 				Expect(dev.GetRdmaSpec().GetRdmaDeviceSpec()).To(HaveLen(0))
 				Expect(dev.GetLinkType()).To(Equal(""))

--- a/pkg/netdevice/vhostNet.go
+++ b/pkg/netdevice/vhostNet.go
@@ -23,3 +23,21 @@ func GetVhostNetDeviceSpec() []*pluginapi.DeviceSpec {
 
 	return deviceSpec
 }
+
+// TunDeviceExist returns true if /dev/net/tun exists
+func TunDeviceExist() bool {
+	_, err := os.Stat("/dev/net/tun")
+	return err == nil
+}
+
+// GetTunDeviceSpec returns an instance of DeviceSpec for Tun
+func GetTunDeviceSpec() []*pluginapi.DeviceSpec {
+	deviceSpec := make([]*pluginapi.DeviceSpec, 0)
+	deviceSpec = append(deviceSpec, &pluginapi.DeviceSpec{
+		HostPath:      "/dev/net/tun",
+		ContainerPath: "/dev/net/tun",
+		Permissions:   "mrw",
+	})
+
+	return deviceSpec
+}


### PR DESCRIPTION
This commit add also the tun device into the container.
This is needed to create tap devices inside the container network namespace

Vhost-net is used to accelerate the dpdk connected to kernel networking using tap devices.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>