### PR TITLE
Add OCP-Sustaining team members to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,8 @@ reviewers:
   - wizhaoredhat
   - zeeke
   - SchSeba
+  - yash2189
+  - kunalmemane
 approvers:
   - zshi-redhat
   - dougbtv
@@ -22,5 +24,7 @@ approvers:
   - wizhaoredhat
   - zeeke
   - SchSeba
+  - yash2189
+  - kunalmemane
 component: "Networking"
 subcomponent: "SR-IOV"


### PR DESCRIPTION
Add yash and kunal from ocp-sustaining team to OWNERS for having permissions to review/approve EUS releases related PRs
